### PR TITLE
Swallow exceptions when getting property values during validation

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -13,5 +13,6 @@
     <PackageVersion Include="coverlet.collector" Version="3.2.0" />
     <PackageVersion Include="BenchmarkDotNet" Version="0.13.2" />
     <PackageVersion Include="Microsoft.Extensions.DependencyInjection" Version="7.0.0" />
+    <PackageVersion Include="Newtonsoft.Json" Version="13.0.3" />
   </ItemGroup>
 </Project>

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -1,7 +1,7 @@
 <Project>
 
   <PropertyGroup>
-    <VersionPrefix>0.9.0</VersionPrefix>
+    <VersionPrefix>0.9.1</VersionPrefix>
     <!-- VersionSuffix used for local builds -->
     <VersionSuffix>dev</VersionSuffix>
     <!-- VersionSuffix to be used for CI builds -->

--- a/src/MiniValidation/MiniValidator.cs
+++ b/src/MiniValidation/MiniValidator.cs
@@ -380,7 +380,12 @@ public static class MiniValidator
 
         foreach (var property in typeProperties)
         {
-            var propertyValue = property.GetValue(target);
+            object? propertyValue = null;
+            try
+            {
+                propertyValue = property.GetValue(target);
+            }
+            catch (Exception) { }
             var propertyValueType = propertyValue?.GetType();
             var (properties, _) = _typeDetailsCache.Get(propertyValueType);
 

--- a/tests/MiniValidation.UnitTests/MiniValidation.UnitTests.csproj
+++ b/tests/MiniValidation.UnitTests/MiniValidation.UnitTests.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <TargetFrameworks>net6.0;net7.0</TargetFrameworks>
     <TargetFrameworks Condition=" $([MSBuild]::IsOsPlatform('Windows')) ">net471;net6.0;net7.0</TargetFrameworks>
-    <LangVersion>10.0</LangVersion>
+    <LangVersion>11.0</LangVersion>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
   </PropertyGroup>
@@ -27,6 +27,7 @@
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" />
+    <PackageReference Include="Newtonsoft.Json" />
   </ItemGroup>
 
 </Project>

--- a/tests/MiniValidation.UnitTests/TestTypes.cs
+++ b/tests/MiniValidation.UnitTests/TestTypes.cs
@@ -246,3 +246,21 @@ class TestTypeForTypeDescriptor
     [MaxLength(1)]
     public string? AnotherProperty { get; set; } = "Test";
 }
+
+class ClassWithJTokenProperty
+{
+    public ClassWithJTokenProperty()
+    {
+        SomeJsonToken = Newtonsoft.Json.Linq.JToken.Parse("""
+            {
+                "prop1": 123,
+                "array1": [1, 2, 3],
+                "obj1": {
+                    "prop2": "abc"
+                }
+            }
+            """);
+    }
+
+    public Newtonsoft.Json.Linq.JToken SomeJsonToken { get; }
+}

--- a/tests/MiniValidation.UnitTests/TryValidate.cs
+++ b/tests/MiniValidation.UnitTests/TryValidate.cs
@@ -413,4 +413,15 @@ public class TryValidate
         Assert.Single(errors["PropertyToBeRequired"]);
         Assert.Single(errors["AnotherProperty"]);
     }
+
+    [Fact]
+    public void CanValidateClassWithJTokenProperty()
+    {
+        var thingToValidate = new ClassWithJTokenProperty();
+
+        var result = MiniValidator.TryValidate(thingToValidate, out var errors);
+
+        Assert.True(result);
+        Assert.Equal(0, errors.Count);
+    }
 }


### PR DESCRIPTION
It's impossible to know if a given property getter will throw during validation due to the state of the object, so just swallow any exception from getting the value.

Fixes #54