### PR TITLE
Add support for external class validators

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -13,5 +13,6 @@
     <PackageVersion Include="coverlet.collector" Version="6.0.2" />
     <PackageVersion Include="BenchmarkDotNet" Version="0.13.12" />
     <PackageVersion Include="Microsoft.Extensions.DependencyInjection" Version="8.0.0" />
+    <PackageVersion Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="8.0.0" />
   </ItemGroup>
 </Project>

--- a/README.md
+++ b/README.md
@@ -41,8 +41,11 @@ class Widget
 var widget = new Widget { Name = "" };
 
 // Get your serviceProvider from wherever makes sense
-var serviceProvider = ...
-var isValid = MiniValidator.TryValidate(widget, serviceProvider, out var errors);
+var services = new ServicesCollection();
+services.AddMiniValidation();
+var serviceProvider = services.CreateServiceProvider();
+var validator = serviceProvider.GetRequiredService<IMiniValidator>();
+var isValid = validator.TryValidate(widget, out var errors);
 
 class Widget : IValidatableObject
 {

--- a/samples/Samples.Console/Samples.Console.csproj
+++ b/samples/Samples.Console/Samples.Console.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
   </PropertyGroup>
 

--- a/samples/Samples.Web/Samples.Web.csproj
+++ b/samples/Samples.Web/Samples.Web.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>net7.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
   </PropertyGroup>

--- a/src/MiniValidation/IAsyncValidatableObject.cs
+++ b/src/MiniValidation/IAsyncValidatableObject.cs
@@ -14,5 +14,9 @@ public interface IAsyncValidatableObject
     /// </summary>
     /// <param name="validationContext">The validation context.</param>
     /// <returns>A collection that holds failed-validation information.</returns>
+#if NET6_0_OR_GREATER
+    ValueTask<IEnumerable<ValidationResult>> ValidateAsync(ValidationContext validationContext);
+#else
     Task<IEnumerable<ValidationResult>> ValidateAsync(ValidationContext validationContext);
+#endif
 }

--- a/src/MiniValidation/IAsyncValidate.cs
+++ b/src/MiniValidation/IAsyncValidate.cs
@@ -1,5 +1,6 @@
 using System.Collections.Generic;
 using System.ComponentModel.DataAnnotations;
+using System.Threading.Tasks;
 
 namespace MiniValidation;
 
@@ -7,7 +8,7 @@ namespace MiniValidation;
 /// Provides a way to add a validator for a type outside the class.
 /// </summary>
 /// <typeparam name="T">The type to validate.</typeparam>
-public interface IValidate<in T>
+public interface IAsyncValidate<in T>
 {
     /// <summary>
     /// Determines whether the specified object is valid.
@@ -15,5 +16,9 @@ public interface IValidate<in T>
     /// <param name="instance">The object instance to validate.</param>
     /// <param name="validationContext">The validation context.</param>
     /// <returns>A collection that holds failed-validation information.</returns>
-    IEnumerable<ValidationResult> Validate(T instance, ValidationContext validationContext);
+#if NET6_0_OR_GREATER
+    ValueTask<IEnumerable<ValidationResult>> ValidateAsync(T instance, ValidationContext validationContext);
+#else
+    Task<IEnumerable<ValidationResult>> ValidateAsync(T instance, ValidationContext validationContext);
+#endif
 }

--- a/src/MiniValidation/IMiniValidator.cs
+++ b/src/MiniValidation/IMiniValidator.cs
@@ -1,0 +1,150 @@
+using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+
+namespace MiniValidation;
+
+/// <summary>
+/// Represents a validator that can validate an object.
+/// </summary>
+public interface IMiniValidator
+{
+    /// <summary>
+    /// Determines if the specified <see cref="Type"/> has anything to validate.
+    /// </summary>
+    /// <remarks>
+    /// Objects of types with nothing to validate will always return <c>true</c> when passed to <see cref="TryValidate{TTarget}(TTarget, bool, out IDictionary{string, string[]})"/>.
+    /// </remarks>
+    /// <param name="targetType">The <see cref="Type"/>.</param>
+    /// <param name="recurse"><c>true</c> to recursively check descendant types; if <c>false</c> only simple values directly on the target type are checked.</param>
+    /// <returns><c>true</c> if <paramref name="targetType"/> has anything to validate, <c>false</c> if not.</returns>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="targetType"/> is <c>null</c>.</exception>
+    bool RequiresValidation(Type targetType, bool recurse = true);
+
+    /// <summary>
+    /// Determines whether the specific object is valid. This method recursively validates descendant objects.
+    /// </summary>
+    /// <param name="target">The object to validate.</param>
+    /// <param name="errors">A dictionary that contains details of each failed validation.</param>
+    /// <returns><c>true</c> if <paramref name="target"/> is valid; otherwise <c>false</c>.</returns>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="target"/> is <c>null</c>.</exception>
+    bool TryValidate<TTarget>(TTarget target, out IDictionary<string, string[]> errors);
+
+    /// <summary>
+    /// Determines whether the specific object is valid.
+    /// </summary>
+    /// <typeparam name="TTarget">The type of the target of validation.</typeparam>
+    /// <param name="target">The object to validate.</param>
+    /// <param name="recurse"><c>true</c> to recursively validate descendant objects; if <c>false</c> only simple values directly on <paramref name="target"/> are validated.</param>
+    /// <param name="errors">A dictionary that contains details of each failed validation.</param>
+    /// <returns><c>true</c> if <paramref name="target"/> is valid; otherwise <c>false</c>.</returns>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="target"/> is <c>null</c>.</exception>
+    bool TryValidate<TTarget>(TTarget target, bool recurse, out IDictionary<string, string[]> errors);
+
+    /// <summary>
+    /// Determines whether the specific object is valid.
+    /// </summary>
+    /// <typeparam name="TTarget"></typeparam>
+    /// <param name="target">The object to validate.</param>
+    /// <param name="recurse"><c>true</c> to recursively validate descendant objects; if <c>false</c> only simple values directly on <paramref name="target"/> are validated.</param>
+    /// <param name="allowAsync"><c>true</c> to allow asynchronous validation if an object in the graph requires it.</param>
+    /// <param name="errors">A dictionary that contains details of each failed validation.</param>
+    /// <returns><c>true</c> if <paramref name="target"/> is valid; otherwise <c>false</c>.</returns>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="target"/> is <c>null</c>.</exception>
+    /// <exception cref="ArgumentException">Throw when <paramref name="target"/> requires async validation and <paramref name="allowAsync"/> is <c>false</c>.</exception>
+    bool TryValidate<TTarget>(TTarget target, bool recurse, bool allowAsync, out IDictionary<string, string[]> errors);
+
+    /// <summary>
+    /// Determines whether the specific object is valid.
+    /// </summary>
+    /// <param name="target">The object to validate.</param>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="target"/> is <c>null</c>.</exception>
+#if NET6_0_OR_GREATER
+    ValueTask<(bool IsValid, IDictionary<string, string[]> Errors)> TryValidateAsync<TTarget>(TTarget target);
+#else
+    Task<(bool IsValid, IDictionary<string, string[]> Errors)> TryValidateAsync<TTarget>(TTarget target);
+#endif
+
+    /// <summary>
+    /// Determines whether the specific object is valid.
+    /// </summary>
+    /// <param name="target">The object to validate.</param>
+    /// <param name="recurse"><c>true</c> to recursively validate descendant objects; if <c>false</c> only simple values directly on <paramref name="target"/> are validated.</param>
+    /// <returns><c>true</c> if <paramref name="target"/> is valid; otherwise <c>false</c> and the validation errors.</returns>
+    /// <exception cref="ArgumentNullException"></exception>
+#if NET6_0_OR_GREATER
+    ValueTask<(bool IsValid, IDictionary<string, string[]> Errors)> TryValidateAsync<TTarget>(TTarget target, bool recurse);
+#else
+    Task<(bool IsValid, IDictionary<string, string[]> Errors)> TryValidateAsync<TTarget>(TTarget target, bool recurse);
+#endif
+    
+    /// <summary>
+    /// Gets a validator for the specified target type.
+    /// </summary>
+    /// <typeparam name="TTarget"></typeparam>
+    /// <returns></returns>
+    IMiniValidator<TTarget> GetValidator<TTarget>();
+}
+
+/// <summary>
+/// Represents a validator that can validate an object of type <typeparamref name="T"/>.
+/// </summary>
+/// <typeparam name="T"></typeparam>
+public interface IMiniValidator<in T>
+{
+
+    /// <summary>
+    /// Determines whether the specific object is valid. This method recursively validates descendant objects.
+    /// </summary>
+    /// <param name="target">The object to validate.</param>
+    /// <param name="errors">A dictionary that contains details of each failed validation.</param>
+    /// <returns><c>true</c> if <paramref name="target"/> is valid; otherwise <c>false</c>.</returns>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="target"/> is <c>null</c>.</exception>
+    bool TryValidate(T target, out IDictionary<string, string[]> errors);
+
+    /// <summary>
+    /// Determines whether the specific object is valid.
+    /// </summary>
+    /// <param name="target">The object to validate.</param>
+    /// <param name="recurse"><c>true</c> to recursively validate descendant objects; if <c>false</c> only simple values directly on <paramref name="target"/> are validated.</param>
+    /// <param name="errors">A dictionary that contains details of each failed validation.</param>
+    /// <returns><c>true</c> if <paramref name="target"/> is valid; otherwise <c>false</c>.</returns>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="target"/> is <c>null</c>.</exception>
+    bool TryValidate(T target, bool recurse, out IDictionary<string, string[]> errors);
+
+    /// <summary>
+    /// Determines whether the specific object is valid.
+    /// </summary>
+    /// <param name="target">The object to validate.</param>
+    /// <param name="recurse"><c>true</c> to recursively validate descendant objects; if <c>false</c> only simple values directly on <paramref name="target"/> are validated.</param>
+    /// <param name="allowAsync"><c>true</c> to allow asynchronous validation if an object in the graph requires it.</param>
+    /// <param name="errors">A dictionary that contains details of each failed validation.</param>
+    /// <returns><c>true</c> if <paramref name="target"/> is valid; otherwise <c>false</c>.</returns>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="target"/> is <c>null</c>.</exception>
+    /// <exception cref="ArgumentException">Throw when <paramref name="target"/> requires async validation and <paramref name="allowAsync"/> is <c>false</c>.</exception>
+    bool TryValidate(T target, bool recurse, bool allowAsync, out IDictionary<string, string[]> errors);
+
+    /// <summary>
+    /// Determines whether the specific object is valid.
+    /// </summary>
+    /// <param name="target">The object to validate.</param>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="target"/> is <c>null</c>.</exception>
+#if NET6_0_OR_GREATER
+    ValueTask<(bool IsValid, IDictionary<string, string[]> Errors)> TryValidateAsync(T target);
+#else
+    Task<(bool IsValid, IDictionary<string, string[]> Errors)> TryValidateAsync(T target);
+#endif
+
+    /// <summary>
+    /// Determines whether the specific object is valid.
+    /// </summary>
+    /// <param name="target">The object to validate.</param>
+    /// <param name="recurse"><c>true</c> to recursively validate descendant objects; if <c>false</c> only simple values directly on <paramref name="target"/> are validated.</param>
+    /// <returns><c>true</c> if <paramref name="target"/> is valid; otherwise <c>false</c> and the validation errors.</returns>
+    /// <exception cref="ArgumentNullException"></exception>
+#if NET6_0_OR_GREATER
+    ValueTask<(bool IsValid, IDictionary<string, string[]> Errors)> TryValidateAsync(T target, bool recurse);
+#else
+    Task<(bool IsValid, IDictionary<string, string[]> Errors)> TryValidateAsync(T target, bool recurse);
+#endif
+}

--- a/src/MiniValidation/IValidatable.cs
+++ b/src/MiniValidation/IValidatable.cs
@@ -1,0 +1,20 @@
+using System.Collections.Generic;
+using System.ComponentModel.DataAnnotations;
+using System.Threading.Tasks;
+
+namespace MiniValidation;
+
+/// <summary>
+/// Provides a way to add a validator for a type outside the class.
+/// </summary>
+/// <typeparam name="T"></typeparam>
+public interface IValidatable<in T>
+{
+    /// <summary>
+    /// Determines whether the specified object is valid.
+    /// </summary>
+    /// <param name="instance">The object instance to validate.</param>
+    /// <param name="validationContext">The validation context.</param>
+    /// <returns>A collection that holds failed-validation information.</returns>
+    Task<IEnumerable<ValidationResult>> ValidateAsync(T instance, ValidationContext validationContext);
+}

--- a/src/MiniValidation/IValidate.cs
+++ b/src/MiniValidation/IValidate.cs
@@ -8,7 +8,7 @@ namespace MiniValidation;
 /// Provides a way to add a validator for a type outside the class.
 /// </summary>
 /// <typeparam name="T"></typeparam>
-public interface IValidatable<in T>
+public interface IValidate<in T>
 {
     /// <summary>
     /// Determines whether the specified object is valid.

--- a/src/MiniValidation/Internal/MiniValidatorImpl.cs
+++ b/src/MiniValidation/Internal/MiniValidatorImpl.cs
@@ -1,0 +1,101 @@
+using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+
+namespace MiniValidation.Internal;
+
+internal class MiniValidatorImpl : IMiniValidator
+{
+    private readonly IServiceProvider _serviceProvider;
+
+    public MiniValidatorImpl(IServiceProvider serviceProvider)
+    {
+        _serviceProvider = serviceProvider;
+    }
+    
+    public bool RequiresValidation(Type targetType, bool recurse = true)
+    {
+        return MiniValidator.RequiresValidation(targetType, recurse, _serviceProvider);
+    }
+
+    public bool TryValidate<TTarget>(TTarget target, out IDictionary<string, string[]> errors)
+    {
+        return MiniValidator.TryValidate(target, _serviceProvider, out errors);
+    }
+
+    public bool TryValidate<TTarget>(TTarget target, bool recurse, out IDictionary<string, string[]> errors)
+    {
+        return MiniValidator.TryValidate(target, _serviceProvider, recurse, out errors);
+    }
+
+    public bool TryValidate<TTarget>(TTarget target, bool recurse, bool allowAsync, out IDictionary<string, string[]> errors)
+    {
+        return MiniValidator.TryValidate(target, _serviceProvider, recurse, allowAsync, out errors);
+    }
+
+#if NET6_0_OR_GREATER
+    public ValueTask<(bool IsValid, IDictionary<string, string[]> Errors)> TryValidateAsync<TTarget>(TTarget target)
+#else
+    public Task<(bool IsValid, IDictionary<string, string[]> Errors)> TryValidateAsync<TTarget>(TTarget target)
+#endif
+    {
+        return MiniValidator.TryValidateAsync(target, _serviceProvider);
+    }
+
+#if NET6_0_OR_GREATER
+    public ValueTask<(bool IsValid, IDictionary<string, string[]> Errors)> TryValidateAsync<TTarget>(TTarget target, bool recurse)
+#else
+    public Task<(bool IsValid, IDictionary<string, string[]> Errors)> TryValidateAsync<TTarget>(TTarget target, bool recurse)
+#endif
+    {
+        return MiniValidator.TryValidateAsync(target, _serviceProvider, recurse);
+    }
+    
+    public IMiniValidator<TTarget> GetValidator<TTarget>()
+    {
+        return new MiniValidatorImpl<TTarget>(_serviceProvider);
+    }
+}
+
+internal class MiniValidatorImpl<T> : IMiniValidator<T>
+{
+    private readonly IServiceProvider _serviceProvider;
+
+    public MiniValidatorImpl(IServiceProvider serviceProvider)
+    {
+        _serviceProvider = serviceProvider;
+    }
+
+    public bool TryValidate(T target, out IDictionary<string, string[]> errors)
+    {
+        return MiniValidator.TryValidate(target, _serviceProvider, out errors);
+    }
+
+    public bool TryValidate(T target, bool recurse, out IDictionary<string, string[]> errors)
+    {
+        return MiniValidator.TryValidate(target, _serviceProvider, recurse, out errors);
+    }
+
+    public bool TryValidate(T target, bool recurse, bool allowAsync, out IDictionary<string, string[]> errors)
+    {
+        return MiniValidator.TryValidate(target, _serviceProvider, recurse, allowAsync, out errors);
+    }
+
+#if NET6_0_OR_GREATER
+    public ValueTask<(bool IsValid, IDictionary<string, string[]> Errors)> TryValidateAsync(T target)
+#else
+    public Task<(bool IsValid, IDictionary<string, string[]> Errors)> TryValidateAsync(T target)
+#endif
+    {
+        return MiniValidator.TryValidateAsync(target, _serviceProvider);
+    }
+
+#if NET6_0_OR_GREATER
+    public ValueTask<(bool IsValid, IDictionary<string, string[]> Errors)> TryValidateAsync(T target, bool recurse)
+#else
+    public Task<(bool IsValid, IDictionary<string, string[]> Errors)> TryValidateAsync(T target, bool recurse)
+#endif
+    {
+        return MiniValidator.TryValidateAsync(target, _serviceProvider, recurse);
+    }
+}

--- a/src/MiniValidation/MiniValidation.csproj
+++ b/src/MiniValidation/MiniValidation.csproj
@@ -14,6 +14,7 @@
 
   <ItemGroup>
     <None Include="../../README.md" Pack="true" PackagePath="\" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" />
     <PackageReference Include="Microsoft.SourceLink.GitHub" PrivateAssets="All" />
     <PackageReference Include="PolySharp">
       <PrivateAssets>all</PrivateAssets>

--- a/src/MiniValidation/MiniValidator.cs
+++ b/src/MiniValidation/MiniValidator.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
@@ -20,7 +20,7 @@ public static class MiniValidator
 {
     private static readonly TypeDetailsCache _typeDetailsCache = new();
     private static readonly ConcurrentDictionary<Type, Type> _validateTypesCache = new();
-    private static readonly ConcurrentDictionary<Type, ValidateAsync> _validateMethodCache = new();
+    private static readonly ConcurrentDictionary<Type, ValidateAsync> _validateMethodsCache = new();
     private static readonly IDictionary<string, string[]> _emptyErrors = new ReadOnlyDictionary<string, string[]>(new Dictionary<string, string[]>());
     private delegate Task<IEnumerable<ValidationResult>> ValidateAsync(object instance, ValidationContext validationContext);
 
@@ -585,7 +585,7 @@ public static class MiniValidator
                     if (!isValid || validator is null)
                         continue;
                     
-                    var validateDelegate = _validateMethodCache.GetOrAdd(validator.GetType(), t =>
+                    var validateDelegate = _validateMethodsCache.GetOrAdd(validator.GetType(), t =>
                     {
                         var validateMethod = t.GetMethod(nameof(IValidate<object>.ValidateAsync));
                         if (validateMethod is null)

--- a/src/MiniValidation/MiniValidator.cs
+++ b/src/MiniValidation/MiniValidator.cs
@@ -32,9 +32,10 @@ public static class MiniValidator
     /// </remarks>
     /// <param name="targetType">The <see cref="Type"/>.</param>
     /// <param name="recurse"><c>true</c> to recursively check descendant types; if <c>false</c> only simple values directly on the target type are checked.</param>
+    /// <param name="serviceProvider">The service provider to use when checking for validators.</param>
     /// <returns><c>true</c> if <paramref name="targetType"/> has anything to validate, <c>false</c> if not.</returns>
     /// <exception cref="ArgumentNullException">Thrown when <paramref name="targetType"/> is <c>null</c>.</exception>
-    public static bool RequiresValidation(Type targetType, bool recurse = true)
+    public static bool RequiresValidation(Type targetType, bool recurse = true, IServiceProvider? serviceProvider = null)
     {
         if (targetType is null)
         {
@@ -44,7 +45,8 @@ public static class MiniValidator
         return typeof(IValidatableObject).IsAssignableFrom(targetType)
             || typeof(IAsyncValidatableObject).IsAssignableFrom(targetType)
             || (recurse && typeof(IEnumerable).IsAssignableFrom(targetType))
-            || _typeDetailsCache.Get(targetType).Properties.Any(p => p.HasValidationAttributes || recurse);
+            || _typeDetailsCache.Get(targetType).Properties.Any(p => p.HasValidationAttributes || recurse)
+            || serviceProvider?.GetService(typeof(IValidatable<>).MakeGenericType(targetType)) != null;
     }
 
     /// <summary>
@@ -163,7 +165,7 @@ public static class MiniValidator
             throw new ArgumentNullException(nameof(target));
         }
 
-        if (!RequiresValidation(target.GetType(), recurse))
+        if (!RequiresValidation(target.GetType(), recurse, serviceProvider))
         {
             errors = _emptyErrors;
 
@@ -306,7 +308,7 @@ public static class MiniValidator
 
         IDictionary<string, string[]>? errors;
 
-        if (!RequiresValidation(target.GetType(), recurse))
+        if (!RequiresValidation(target.GetType(), recurse, serviceProvider))
         {
             errors = _emptyErrors;
 
@@ -415,6 +417,7 @@ public static class MiniValidator
                 (property.Recurse
                  || typeof(IValidatableObject).IsAssignableFrom(propertyValueType)
                  || typeof(IAsyncValidatableObject).IsAssignableFrom(propertyValueType)
+                 || serviceProvider?.GetService(typeof(IValidatable<>).MakeGenericType(propertyValueType!)) != null
                  || properties.Any(p => p.Recurse)))
             {
                 propertiesToRecurse!.Add(property, propertyValue);
@@ -529,6 +532,47 @@ public static class MiniValidator
             {
                 ProcessValidationResults(validatableResults, workingErrors, prefix);
                 isValid = workingErrors.Count == 0 && isValid;
+            }
+        }
+
+        if (isValid)
+        {
+            var validators = (IEnumerable?)serviceProvider?.GetService(typeof(IEnumerable<>).MakeGenericType(typeof(IValidatable<>).MakeGenericType(targetType)));
+            if (validators != null)
+            {
+                foreach (var validator in validators)
+                {
+                    if (!isValid)
+                        continue;
+
+                    var validatorMethod = validator.GetType().GetMethod(nameof(IValidatable<object>.ValidateAsync));
+                    if (validatorMethod is null)
+                    {
+                        throw new InvalidOperationException(
+                            $"The type {validators.GetType().Name} does not implement the required method 'Task<IEnumerable<ValidationResult>> ValidateAsync(object, ValidationContext)'.");
+                    }
+
+                    var validateTask = (Task<IEnumerable<ValidationResult>>?)validatorMethod.Invoke(validator,
+                            new[] { target, validationContext });
+                    if (validateTask is null)
+                    {
+                        throw new InvalidOperationException(
+                            $"The type {validators.GetType().Name} does not implement the required method 'Task<IEnumerable<ValidationResult>> ValidateAsync(object, ValidationContext)'.");
+                    }
+
+                    // Reset validation context
+                    validationContext.MemberName = null;
+                    validationContext.DisplayName = validationContext.ObjectType.Name;
+
+                    ThrowIfAsyncNotAllowed(validateTask.IsCompleted, allowAsync);
+
+                    var validatableResults = await validateTask.ConfigureAwait(false);
+                    if (validatableResults is not null)
+                    {
+                        ProcessValidationResults(validatableResults, workingErrors, prefix);
+                        isValid = workingErrors.Count == 0 && isValid;
+                    }
+                }
             }
         }
 

--- a/src/MiniValidation/ServiceProviderExtensions.cs
+++ b/src/MiniValidation/ServiceProviderExtensions.cs
@@ -1,0 +1,47 @@
+using System;
+using System.Linq;
+using Microsoft.Extensions.DependencyInjection;
+using MiniValidation.Internal;
+
+namespace MiniValidation;
+
+/// <summary>
+/// Extension methods for <see cref="IServiceProvider"/>.
+/// </summary>
+public static class ServiceProviderExtensions
+{
+    /// <summary>
+    /// Adds IValidator service to the service collection.
+    /// </summary>
+    /// <param name="services">The <see cref="IServiceCollection"/> to add the service to.</param>
+    /// <returns>The <see cref="IServiceCollection"/> so that additional calls can be chained.</returns>
+    public static IServiceCollection AddMiniValidator(this IServiceCollection services)
+    {
+        services.AddSingleton<IMiniValidator, MiniValidatorImpl>();
+        services.AddSingleton(typeof(IMiniValidator<>), typeof(MiniValidatorImpl<>));
+        return services;
+    }
+
+    /// <summary>
+    /// Adds a class based validator that implements <see cref="IValidate{T}"/> or <see cref="IAsyncValidate{T}"/> to the service collection.
+    /// </summary>
+    /// <param name="services">The <see cref="IServiceCollection"/> to add the service to.</param>
+    /// <param name="lifetime">The <see cref="ServiceLifetime"/> of the service.</param>
+    /// <typeparam name="TValidator">A class that implements <see cref="IValidate{T}"/> or <see cref="IAsyncValidate{T}"/></typeparam>
+    /// <returns>The <see cref="IServiceCollection"/> so that additional calls can be chained.</returns>
+    public static IServiceCollection AddClassMiniValidator<TValidator>(this IServiceCollection services, ServiceLifetime lifetime = ServiceLifetime.Transient)
+        where TValidator : class
+    {
+        var validators = typeof(TValidator)
+            .GetInterfaces()
+            .Where(i => i.IsGenericType && i.GetGenericTypeDefinition() == typeof(IAsyncValidate<>) || i.GetGenericTypeDefinition() == typeof(IValidate<>))
+            .ToArray();
+        
+        foreach (var validator in validators)
+        {
+            services.Add(new ServiceDescriptor(validator, null, typeof(TValidator), lifetime));
+        }
+        
+        return services;
+    }
+}

--- a/src/MiniValidation/TypeDetailsCache.cs
+++ b/src/MiniValidation/TypeDetailsCache.cs
@@ -183,16 +183,18 @@ internal class TypeDetailsCache
             }
         }
 
-        var propertyAttributes = property.GetCustomAttributes();
-        var customAttributes = paramAttributes is not null
-            ? paramAttributes.Concat(propertyAttributes)
-            : propertyAttributes;
+        var customAttributes = new List<Attribute>();
 
-        if (TryGetAttributesViaTypeDescriptor(property, out var typeDescriptorAttributes))
+        var propertyAttributes = property.GetCustomAttributes();
+        customAttributes.AddRange(propertyAttributes);
+        if (paramAttributes is not null)
         {
-            customAttributes = customAttributes
-                .Concat(typeDescriptorAttributes.Cast<Attribute>())
-                .Distinct();
+            customAttributes.AddRange(paramAttributes);
+        }
+
+        if (customAttributes.Count == 0 && TryGetAttributesViaTypeDescriptor(property, out var typeDescriptorAttributes))
+        {
+            customAttributes.AddRange(typeDescriptorAttributes);
         }
 
         foreach (var attr in customAttributes)

--- a/tests/MiniValidation.Benchmarks/MiniValidation.Benchmarks.csproj
+++ b/tests/MiniValidation.Benchmarks/MiniValidation.Benchmarks.csproj
@@ -2,8 +2,8 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFrameworks>net6.0;net7.0</TargetFrameworks>
-    <TargetFrameworks Condition=" $([MSBuild]::IsOsPlatform('Windows')) ">net471;net6.0;net7.0</TargetFrameworks>
+    <TargetFrameworks>net6.0;net7.0;net8.0</TargetFrameworks>
+    <TargetFrameworks Condition=" $([MSBuild]::IsOsPlatform('Windows')) ">net471;net6.0;net7.0;net8.0</TargetFrameworks>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <LangVersion>10</LangVersion>
@@ -11,6 +11,7 @@
 
   <ItemGroup>
     <PackageReference Include="BenchmarkDotNet" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" />
   </ItemGroup>
 
   <ItemGroup>

--- a/tests/MiniValidation.UnitTests/TestTypes.cs
+++ b/tests/MiniValidation.UnitTests/TestTypes.cs
@@ -91,7 +91,12 @@ class TestClassLevelAsyncValidatableOnlyType : IAsyncValidatableObject
 {
     public int TwentyOrMore { get; set; } = 20;
 
+#if NET6_0_OR_GREATER
+
+    public async ValueTask<IEnumerable<ValidationResult>> ValidateAsync(ValidationContext validationContext)
+#else
     public async Task<IEnumerable<ValidationResult>> ValidateAsync(ValidationContext validationContext)
+#endif
     {
         await Task.Yield();
 
@@ -114,7 +119,27 @@ class TestClassLevel
 
 class TestClassLevelValidator : IValidate<TestClassLevel>
 {
+    public IEnumerable<ValidationResult> Validate(TestClassLevel instance, ValidationContext validationContext)
+    {
+        List<ValidationResult>? errors = null;
+
+        if (instance.TwentyOrMore < 20)
+        {
+            errors ??= new List<ValidationResult>();
+            errors.Add(new ValidationResult($"The field {validationContext.DisplayName} must have a value greater than 20.", new[] { nameof(TestClassLevel.TwentyOrMore) }));
+        }
+
+        return errors ?? Enumerable.Empty<ValidationResult>();
+    }
+}
+
+class TestClassLevelAsyncValidator : IAsyncValidate<TestClassLevel>
+{
+#if NET6_0_OR_GREATER
+    public async ValueTask<IEnumerable<ValidationResult>> ValidateAsync(TestClassLevel instance, ValidationContext validationContext)
+#else
     public async Task<IEnumerable<ValidationResult>> ValidateAsync(TestClassLevel instance, ValidationContext validationContext)
+#endif
     {
         await Task.Yield();
 
@@ -132,10 +157,8 @@ class TestClassLevelValidator : IValidate<TestClassLevel>
 
 class ExtraTestClassLevelValidator : IValidate<TestClassLevel>
 {
-    public async Task<IEnumerable<ValidationResult>> ValidateAsync(TestClassLevel instance, ValidationContext validationContext)
+    public IEnumerable<ValidationResult> Validate(TestClassLevel instance, ValidationContext validationContext)
     {
-        await Task.Yield();
-
         List<ValidationResult>? errors = null;
 
         if (instance.TwentyOrMore > 20)
@@ -150,7 +173,11 @@ class ExtraTestClassLevelValidator : IValidate<TestClassLevel>
 
 class TestClassLevelAsyncValidatableOnlyTypeWithServiceProvider : IAsyncValidatableObject
 {
+#if NET6_0_OR_GREATER
+    public async ValueTask<IEnumerable<ValidationResult>> ValidateAsync(ValidationContext validationContext)
+#else
     public async Task<IEnumerable<ValidationResult>> ValidateAsync(ValidationContext validationContext)
+#endif
     {
         await Task.Yield();
 
@@ -223,7 +250,11 @@ class TestAsyncValidatableChildType : TestChildType, IAsyncValidatableObject
 {
     public int TwentyOrMore { get; set; } = 20;
 
+#if NET6_0_OR_GREATER
+    public async ValueTask<IEnumerable<ValidationResult>> ValidateAsync(ValidationContext validationContext)
+#else
     public async Task<IEnumerable<ValidationResult>> ValidateAsync(ValidationContext validationContext)
+#endif
     {
         var taskToAwait = validationContext.GetService<Task>();
         if (taskToAwait is not null)

--- a/tests/MiniValidation.UnitTests/TestTypes.cs
+++ b/tests/MiniValidation.UnitTests/TestTypes.cs
@@ -112,7 +112,7 @@ class TestClassLevel
     public int TwentyOrMore { get; set; } = 20;
 }
 
-class TestClassLevelValidator : IValidatable<TestClassLevel>
+class TestClassLevelValidator : IValidate<TestClassLevel>
 {
     public async Task<IEnumerable<ValidationResult>> ValidateAsync(TestClassLevel instance, ValidationContext validationContext)
     {
@@ -130,7 +130,7 @@ class TestClassLevelValidator : IValidatable<TestClassLevel>
     }
 }
 
-class ExtraTestClassLevelValidator : IValidatable<TestClassLevel>
+class ExtraTestClassLevelValidator : IValidate<TestClassLevel>
 {
     public async Task<IEnumerable<ValidationResult>> ValidateAsync(TestClassLevel instance, ValidationContext validationContext)
     {

--- a/tests/MiniValidation.UnitTests/TestTypes.cs
+++ b/tests/MiniValidation.UnitTests/TestTypes.cs
@@ -107,6 +107,47 @@ class TestClassLevelAsyncValidatableOnlyType : IAsyncValidatableObject
     }
 }
 
+class TestClassLevel
+{
+    public int TwentyOrMore { get; set; } = 20;
+}
+
+class TestClassLevelValidator : IValidatable<TestClassLevel>
+{
+    public async Task<IEnumerable<ValidationResult>> ValidateAsync(TestClassLevel instance, ValidationContext validationContext)
+    {
+        await Task.Yield();
+
+        List<ValidationResult>? errors = null;
+
+        if (instance.TwentyOrMore < 20)
+        {
+            errors ??= new List<ValidationResult>();
+            errors.Add(new ValidationResult($"The field {validationContext.DisplayName} must have a value greater than 20.", new[] { nameof(TestClassLevel.TwentyOrMore) }));
+        }
+
+        return errors ?? Enumerable.Empty<ValidationResult>();
+    }
+}
+
+class ExtraTestClassLevelValidator : IValidatable<TestClassLevel>
+{
+    public async Task<IEnumerable<ValidationResult>> ValidateAsync(TestClassLevel instance, ValidationContext validationContext)
+    {
+        await Task.Yield();
+
+        List<ValidationResult>? errors = null;
+
+        if (instance.TwentyOrMore > 20)
+        {
+            errors ??= new List<ValidationResult>();
+            errors.Add(new ValidationResult($"The field {validationContext.DisplayName} must have a value less than 20.", new[] { nameof(TestClassLevel.TwentyOrMore) }));
+        }
+
+        return errors ?? Enumerable.Empty<ValidationResult>();
+    }
+}
+
 class TestClassLevelAsyncValidatableOnlyTypeWithServiceProvider : IAsyncValidatableObject
 {
     public async Task<IEnumerable<ValidationResult>> ValidateAsync(ValidationContext validationContext)

--- a/tests/MiniValidation.UnitTests/TryValidate.cs
+++ b/tests/MiniValidation.UnitTests/TryValidate.cs
@@ -401,7 +401,7 @@ public class TryValidate
     public void TryValidate_With_Validator()
     {
         var serviceCollection = new ServiceCollection();
-        serviceCollection.AddSingleton<IValidatable<TestClassLevel>, TestClassLevelValidator>();
+        serviceCollection.AddSingleton<IValidate<TestClassLevel>, TestClassLevelValidator>();
         var serviceProvider = serviceCollection.BuildServiceProvider();
 
         var thingToValidate = new TestClassLevel
@@ -419,7 +419,7 @@ public class TryValidate
     public async Task TryValidateAsync_With_Validator()
     {
         var serviceCollection = new ServiceCollection();
-        serviceCollection.AddSingleton<IValidatable<TestClassLevel>, TestClassLevelValidator>();
+        serviceCollection.AddSingleton<IValidate<TestClassLevel>, TestClassLevelValidator>();
         var serviceProvider = serviceCollection.BuildServiceProvider();
 
         var thingToValidate = new TestClassLevel
@@ -438,8 +438,8 @@ public class TryValidate
     public async Task TryValidateAsync_With_Multiple_Validators()
     {
         var serviceCollection = new ServiceCollection();
-        serviceCollection.AddSingleton<IValidatable<TestClassLevel>, TestClassLevelValidator>();
-        serviceCollection.AddSingleton<IValidatable<TestClassLevel>, ExtraTestClassLevelValidator>();
+        serviceCollection.AddSingleton<IValidate<TestClassLevel>, TestClassLevelValidator>();
+        serviceCollection.AddSingleton<IValidate<TestClassLevel>, ExtraTestClassLevelValidator>();
         var serviceProvider = serviceCollection.BuildServiceProvider();
 
         var thingToValidate = new TestClassLevel

--- a/tests/MiniValidation.UnitTests/TryValidate.cs
+++ b/tests/MiniValidation.UnitTests/TryValidate.cs
@@ -398,6 +398,63 @@ public class TryValidate
     }
 
     [Fact]
+    public void TryValidate_With_Validator()
+    {
+        var serviceCollection = new ServiceCollection();
+        serviceCollection.AddSingleton<IValidatable<TestClassLevel>, TestClassLevelValidator>();
+        var serviceProvider = serviceCollection.BuildServiceProvider();
+
+        var thingToValidate = new TestClassLevel
+        {
+            TwentyOrMore = 12
+        };
+
+        Assert.Throws<InvalidOperationException>(() =>
+        {
+            var isValid = MiniValidator.TryValidate(thingToValidate, serviceProvider, out var errors);
+        });
+    }
+
+    [Fact]
+    public async Task TryValidateAsync_With_Validator()
+    {
+        var serviceCollection = new ServiceCollection();
+        serviceCollection.AddSingleton<IValidatable<TestClassLevel>, TestClassLevelValidator>();
+        var serviceProvider = serviceCollection.BuildServiceProvider();
+
+        var thingToValidate = new TestClassLevel
+        {
+            TwentyOrMore = 12
+        };
+
+        var (isValid, errors) = await MiniValidator.TryValidateAsync(thingToValidate, serviceProvider);
+
+        Assert.False(isValid);
+        Assert.Single(errors);
+        Assert.Equal(nameof(TestValidatableType.TwentyOrMore), errors.Keys.First());
+    }
+
+    [Fact]
+    public async Task TryValidateAsync_With_Multiple_Validators()
+    {
+        var serviceCollection = new ServiceCollection();
+        serviceCollection.AddSingleton<IValidatable<TestClassLevel>, TestClassLevelValidator>();
+        serviceCollection.AddSingleton<IValidatable<TestClassLevel>, ExtraTestClassLevelValidator>();
+        var serviceProvider = serviceCollection.BuildServiceProvider();
+
+        var thingToValidate = new TestClassLevel
+        {
+            TwentyOrMore = 22
+        };
+
+        var (isValid, errors) = await MiniValidator.TryValidateAsync(thingToValidate, serviceProvider);
+
+        Assert.False(isValid);
+        Assert.Single(errors);
+        Assert.Equal(nameof(TestValidatableType.TwentyOrMore), errors.Keys.First());
+    }
+
+    [Fact]
     public void TryValidate_Enumerable_With_ServiceProvider()
     {
         var serviceCollection = new ServiceCollection();


### PR DESCRIPTION
Adds support for defining `IValidate<T>` classes to provide validation for class types outside of the model class where you are unable to alter the target model or would prefer to keep the model classes simple and not have the `IValidatableObject` interface implementation.