### PR TITLE
Drop unsupported TFMs & update packages

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -3,13 +3,13 @@
     <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
   </PropertyGroup>
   <ItemGroup>
-    <PackageVersion Include="PolySharp" Version="1.14.1" />
+    <PackageVersion Include="PolySharp" Version="1.15.0" />
     <PackageVersion Include="System.ComponentModel.Annotations" Version="5.0.0" />
     <PackageVersion Include="Microsoft.SourceLink.GitHub" Version="8.0.0" />
-    <PackageVersion Include="Swashbuckle.AspNetCore" Version="6.5.0" />
-    <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.9.0" />
-    <PackageVersion Include="xunit" Version="2.7.1" />
-    <PackageVersion Include="xunit.runner.visualstudio" Version="2.5.8" />
+    <PackageVersion Include="Swashbuckle.AspNetCore" Version="7.2.0" />
+    <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
+    <PackageVersion Include="xunit" Version="2.9.2" />
+    <PackageVersion Include="xunit.runner.visualstudio" Version="2.8.2" />
     <PackageVersion Include="coverlet.collector" Version="6.0.2" />
     <PackageVersion Include="BenchmarkDotNet" Version="0.13.12" />
     <PackageVersion Include="Microsoft.Extensions.DependencyInjection" Version="8.0.0" />

--- a/samples/Samples.Console/Program.cs
+++ b/samples/Samples.Console/Program.cs
@@ -5,7 +5,7 @@ var title = args.Length > 0 ? args[0] : "";
 
 var widgets = new List<Widget>
 {
-    new Widget { Name = title },
+    new() { Name = title },
     new WidgetWithCustomValidation { Name = title }
 };
 

--- a/samples/Samples.Web/Program.cs
+++ b/samples/Samples.Web/Program.cs
@@ -1,5 +1,6 @@
 using System.ComponentModel.DataAnnotations;
 using Microsoft.AspNetCore.Http.HttpResults;
+using Microsoft.AspNetCore.Mvc;
 using MiniValidation;
 
 var builder = WebApplication.CreateBuilder(args);
@@ -23,6 +24,9 @@ app.MapGet("/widgets", () =>
 app.MapGet("/widgets/{name}", (string name) =>
     new Widget { Name = name });
 
+app.MapGet("/widgets2/{name}", ([AsParameters] GetWidgets2Model model) =>
+    new Widget { Name = model.Name });
+
 app.MapPost("/widgets", Results<ValidationProblem, Created<Widget>> (Widget widget) =>
     !MiniValidator.TryValidate(widget, out var errors)
         ? TypedResults.ValidationProblem(errors)
@@ -34,6 +38,12 @@ app.MapPost("/widgets/custom-validation", Results<ValidationProblem, Created<Wid
         : TypedResults.Created($"/widgets/{widget.Name}", widget));
 
 app.Run();
+
+class GetWidgets2Model
+{
+    [FromRoute, RegularExpression("^(hello|world)$")]
+    public string? Name { get; set; }
+}
 
 class Widget
 {
@@ -49,7 +59,7 @@ class WidgetWithCustomValidation : Widget, IValidatableObject
     {
         if (string.Equals(Name, "Widget", StringComparison.OrdinalIgnoreCase))
         {
-            yield return new($"Cannot name a widget '{Name}'.", new[] { nameof(Name) });
+            yield return new($"Cannot name a widget '{Name}'.", [nameof(Name)]);
         }
     }
 }

--- a/samples/Samples.Web/Samples.Web.csproj
+++ b/samples/Samples.Web/Samples.Web.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>net7.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
   </PropertyGroup>

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -1,7 +1,7 @@
 <Project>
 
   <PropertyGroup>
-    <VersionPrefix>0.9.1</VersionPrefix>
+    <VersionPrefix>0.10.0</VersionPrefix>
     <!-- VersionSuffix used for local builds -->
     <VersionSuffix>dev</VersionSuffix>
     <!-- VersionSuffix to be used for CI builds -->

--- a/src/MiniValidation/MiniValidation.csproj
+++ b/src/MiniValidation/MiniValidation.csproj
@@ -1,8 +1,8 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <Description>A minimalist validation library built atop the existing validation features in .NET's `System.ComponentModel.DataAnnotations` namespace.</Description>
-    <TargetFrameworks>netstandard2.0;net6.0</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;net8.0</TargetFrameworks>
     <PackageTags>ComponentModel DataAnnotations validation</PackageTags>
     <PackageReadmeFile>README.md</PackageReadmeFile>
     <LangVersion>10.0</LangVersion>

--- a/tests/MiniValidation.Benchmarks/MiniValidation.Benchmarks.csproj
+++ b/tests/MiniValidation.Benchmarks/MiniValidation.Benchmarks.csproj
@@ -1,9 +1,9 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFrameworks>net6.0;net7.0</TargetFrameworks>
-    <TargetFrameworks Condition=" $([MSBuild]::IsOsPlatform('Windows')) ">net471;net6.0;net7.0</TargetFrameworks>
+    <TargetFrameworks>net8.0</TargetFrameworks>
+    <TargetFrameworks Condition=" $([MSBuild]::IsOsPlatform('Windows')) ">net471;net8.0</TargetFrameworks>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <LangVersion>10</LangVersion>

--- a/tests/MiniValidation.UnitTests/MiniValidation.UnitTests.csproj
+++ b/tests/MiniValidation.UnitTests/MiniValidation.UnitTests.csproj
@@ -1,8 +1,8 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net6.0;net7.0;net8.0</TargetFrameworks>
-    <TargetFrameworks Condition=" $([MSBuild]::IsOsPlatform('Windows')) ">net471;net6.0;net7.0;net8.0</TargetFrameworks>
+    <TargetFrameworks>net8.0</TargetFrameworks>
+    <TargetFrameworks Condition=" $([MSBuild]::IsOsPlatform('Windows')) ">net471;net8.0</TargetFrameworks>
     <LangVersion>10.0</LangVersion>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>


### PR DESCRIPTION
Dropping `net6.0` and `net7.0` and updating dependency package versions.

Didn't update `BenchmarksDotNet` due to https://github.com/dotnet/BenchmarkDotNet/issues/2678

Bumps version to 0.10.0