### PR TITLE
Define a CollectionDebugView to improve the debug experience

### DIFF
--- a/src/MiniValidation/AdaptiveCapacityDictionary.cs
+++ b/src/MiniValidation/AdaptiveCapacityDictionary.cs
@@ -15,6 +15,8 @@ namespace MiniValidation;
 /// <summary>
 /// An <see cref="IDictionary{TKey, TValue}"/> type to hold a small amount of items (10 or less in the common case).
 /// </summary>
+[DebuggerDisplay("Count = {Count}")]
+[DebuggerTypeProxy(typeof(Diagnostics.CollectionDebugView))]
 internal sealed class AdaptiveCapacityDictionary<TKey, TValue> : IDictionary<TKey, TValue>, IReadOnlyDictionary<TKey, TValue> where TKey : notnull
 {
     // Threshold for size of array to use.

--- a/src/MiniValidation/Diagnostics/CollectionDebugView.cs
+++ b/src/MiniValidation/Diagnostics/CollectionDebugView.cs
@@ -1,0 +1,29 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+#if NET6_0_OR_GREATER
+using System.Collections;
+using System.Diagnostics;
+using System.Diagnostics.CodeAnalysis;
+using System.Linq;
+
+namespace MiniValidation.Diagnostics;
+
+/// <summary>Allows the debugger to display collections.</summary>
+[ExcludeFromCodeCoverage]
+internal sealed class CollectionDebugView
+{
+    public CollectionDebugView(IEnumerable enumeration) => _enumeration = enumeration;
+
+		/// <summary>A reference to the enumeration to display.</summary>
+		private readonly IEnumerable _enumeration;
+
+    /// <summary>The array that is shown by the debugger.</summary>
+    /// <remarks>
+    /// Every time the enumeration is shown in the debugger, a new array is created.
+    /// By doing this, it is always in sync with the current state of the enumeration.
+    /// </remarks>
+    [DebuggerBrowsable(DebuggerBrowsableState.RootHidden)]
+    public object[] Items => _enumeration.Cast<object>().ToArray();
+}
+#endif


### PR DESCRIPTION
Just as the title says: define a `[DebuggerTypeProxy(typeof(Diagnostics.CollectionDebugView))]` to improve the debug experience on `AdaptiveCapacityDictionary`.