### PR TITLE
Fix #68/#34 collect all validation errors

### DIFF
--- a/.github/workflows/_build.yml
+++ b/.github/workflows/_build.yml
@@ -19,7 +19,10 @@ jobs:
     - name: Install .NET SDK
       uses: actions/setup-dotnet@v4
       with:
-        dotnet-version: 6.0.x
+        dotnet-version: |
+          8.0.x
+          9.0.x
+          10.0.x
         global-json-file: "./global.json"
     
     - name: Restore dependencies

--- a/global.json
+++ b/global.json
@@ -1,6 +1,6 @@
 {
   "sdk": {
-    "version": "8.0.100",
+    "version": "10.0.100",
     "rollForward": "latestFeature"
   }
 }

--- a/samples/Samples.Console/Samples.Console.csproj
+++ b/samples/Samples.Console/Samples.Console.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
   </PropertyGroup>
 

--- a/samples/Samples.Web/Samples.Web.csproj
+++ b/samples/Samples.Web/Samples.Web.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>net7.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
   </PropertyGroup>

--- a/src/MiniValidation/MiniValidation.csproj
+++ b/src/MiniValidation/MiniValidation.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <Description>A minimalist validation library built atop the existing validation features in .NET's `System.ComponentModel.DataAnnotations` namespace.</Description>
-    <TargetFrameworks>netstandard2.0;net6.0</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;net8.0</TargetFrameworks>
     <PackageTags>ComponentModel DataAnnotations validation</PackageTags>
     <PackageReadmeFile>README.md</PackageReadmeFile>
     <LangVersion>10.0</LangVersion>

--- a/src/MiniValidation/MiniValidator.cs
+++ b/src/MiniValidation/MiniValidator.cs
@@ -503,7 +503,7 @@ public static class MiniValidator
             }
         }
 
-        if (isValid && typeof(IValidatableObject).IsAssignableFrom(targetType))
+        if (typeof(IValidatableObject).IsAssignableFrom(targetType))
         {
             var validatable = (IValidatableObject)target;
 
@@ -514,12 +514,11 @@ public static class MiniValidator
             var validatableResults = validatable.Validate(validationContext);
             if (validatableResults is not null)
             {
-                ProcessValidationResults(validatableResults, workingErrors, prefix);
-                isValid = workingErrors.Count == 0 && isValid;
+                isValid = ProcessValidationResults(validatableResults, workingErrors, prefix) && isValid;
             }
         }
 
-        if (isValid && typeof(IAsyncValidatableObject).IsAssignableFrom(targetType))
+        if ((isValid || allowAsync) && typeof(IAsyncValidatableObject).IsAssignableFrom(targetType))
         {
             var validatable = (IAsyncValidatableObject)target;
 
@@ -533,8 +532,7 @@ public static class MiniValidator
             var validatableResults = await validateTask.ConfigureAwait(false);
             if (validatableResults is not null)
             {
-                ProcessValidationResults(validatableResults, workingErrors, prefix);
-                isValid = workingErrors.Count == 0 && isValid;
+                isValid = ProcessValidationResults(validatableResults, workingErrors, prefix) && isValid;
             }
         }
 
@@ -598,12 +596,7 @@ public static class MiniValidator
                     throw;
                 }
 
-                isValid = await validateTask.ConfigureAwait(false);
-
-                if (!isValid)
-                {
-                    break;
-                }
+                isValid = await validateTask.ConfigureAwait(false) && isValid;
                 index++;
             }
         }
@@ -633,10 +626,13 @@ public static class MiniValidator
         return result;
     }
 
-    private static void ProcessValidationResults(IEnumerable<ValidationResult> validationResults, Dictionary<string, List<string>> errors, string? prefix)
+    private static bool ProcessValidationResults(IEnumerable<ValidationResult> validationResults, Dictionary<string, List<string>> errors, string? prefix)
     {
+        var isValid = true;
+
         foreach (var result in validationResults)
         {
+            isValid = false;
             var hasMemberNames = false;
             foreach (var memberName in result.MemberNames)
             {
@@ -652,13 +648,27 @@ public static class MiniValidator
             if (!hasMemberNames)
             {
                 // Class level error message
-                var key = "";
+                var key = GetClassLevelKey(prefix);
                 if (!errors.ContainsKey(key))
                 {
                     errors.Add(key, new());
                 }
                 errors[key].Add(result.ErrorMessage ?? "");
             }
+        }
+
+        return isValid;
+
+        static string GetClassLevelKey(string? prefix)
+        {
+            if (string.IsNullOrEmpty(prefix))
+            {
+                return "";
+            }
+
+            return prefix!.EndsWith(".", StringComparison.Ordinal)
+                ? prefix.Substring(0, prefix.Length - 1)
+                : prefix;
         }
     }
 

--- a/src/MiniValidation/TypeDetailsCache.cs
+++ b/src/MiniValidation/TypeDetailsCache.cs
@@ -14,6 +14,21 @@ internal class TypeDetailsCache
     private static readonly PropertyDetails[] _emptyPropertyDetails = Array.Empty<PropertyDetails>();
     private readonly ConcurrentDictionary<Type, (PropertyDetails[] Properties, bool RequiresAsync)> _cache = new();
 
+    public TypeDetailsCache()
+    {
+        TypeDescriptor.Refreshed += args =>
+        {
+            if (args.TypeChanged is { } type)
+            {
+                _cache.TryRemove(type, out _);
+            }
+            else
+            {
+                _cache.Clear();
+            }
+        };
+    }
+
     public (PropertyDetails[] Properties, bool RequiresAsync) Get(Type? type)
     {
         if (type is null)
@@ -21,12 +36,13 @@ internal class TypeDetailsCache
             return (_emptyPropertyDetails, false);
         }
 
-        if (!_cache.ContainsKey(type))
+        (PropertyDetails[] Properties, bool RequiresAsync) details;
+        while (!_cache.TryGetValue(type, out details))
         {
             Visit(type);
         }
 
-        return _cache[type];
+        return details;
     }
 
     private void Visit(Type type)

--- a/tests/MiniValidation.Benchmarks/MiniValidation.Benchmarks.csproj
+++ b/tests/MiniValidation.Benchmarks/MiniValidation.Benchmarks.csproj
@@ -2,8 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFrameworks>net6.0;net7.0</TargetFrameworks>
-    <TargetFrameworks Condition=" $([MSBuild]::IsOsPlatform('Windows')) ">net471;net6.0;net7.0</TargetFrameworks>
+    <TargetFrameworks>net8.0;net9.0;net10.0</TargetFrameworks>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <LangVersion>10</LangVersion>

--- a/tests/MiniValidation.UnitTests/MiniValidation.UnitTests.csproj
+++ b/tests/MiniValidation.UnitTests/MiniValidation.UnitTests.csproj
@@ -1,8 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net6.0;net7.0;net8.0</TargetFrameworks>
-    <TargetFrameworks Condition=" $([MSBuild]::IsOsPlatform('Windows')) ">net471;net6.0;net7.0;net8.0</TargetFrameworks>
+    <TargetFrameworks>net8.0;net9.0;net10.0</TargetFrameworks>
     <LangVersion>10.0</LangVersion>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>

--- a/tests/MiniValidation.UnitTests/Recursion.cs
+++ b/tests/MiniValidation.UnitTests/Recursion.cs
@@ -160,7 +160,7 @@ public class Recursion
     }
 
     [Fact]
-    public void First_Error_In_Root_Enumerable_Returns_Immediately()
+    public void All_Errors_In_Root_Enumerable_Are_Reported()
     {
         var thingToValidate = new List<TestType>
         {
@@ -171,13 +171,13 @@ public class Recursion
         var result = MiniValidator.TryValidate(thingToValidate, recurse: true, out var errors);
 
         Assert.False(result);
-        Assert.Single(errors);
-        var entry = Assert.Single(errors);
-        Assert.Equal($"[0].{nameof(TestType.RequiredName)}", entry.Key);
+        Assert.Equal(2, errors.Count);
+        Assert.Contains($"[0].{nameof(TestType.RequiredName)}", errors.Keys);
+        Assert.Contains($"[1].{nameof(TestType.RequiredName)}", errors.Keys);
     }
 
     [Fact]
-    public void First_Error_In_Descendant_Enumerable_Returns_Immediately()
+    public void All_Errors_In_Descendant_Enumerable_Are_Reported()
     {
         var thingToValidate = new TestType();
         thingToValidate.Children.Add(new() { MinLengthFive = "123" });
@@ -186,9 +186,26 @@ public class Recursion
         var result = MiniValidator.TryValidate(thingToValidate, recurse: true, out var errors);
 
         Assert.False(result);
-        Assert.Single(errors);
-        var entry = Assert.Single(errors);
-        Assert.Equal($"{nameof(TestType.Children)}[0].{nameof(TestChildType.MinLengthFive)}", entry.Key);
+        Assert.Equal(2, errors.Count);
+        Assert.Contains($"{nameof(TestType.Children)}[0].{nameof(TestChildType.MinLengthFive)}", errors.Keys);
+        Assert.Contains($"{nameof(TestType.Children)}[1].{nameof(TestChildType.RequiredCategory)}", errors.Keys);
+    }
+
+    [Fact]
+    public void Class_Level_Errors_In_Root_Enumerable_Are_Keyed_By_Item()
+    {
+        var thingToValidate = new List<TestClassLevelValidatableOnlyType>
+        {
+            new() { TwentyOrMore = 12 },
+            new() { TwentyOrMore = 12 },
+        };
+
+        var result = MiniValidator.TryValidate(thingToValidate, recurse: true, out var errors);
+
+        Assert.False(result);
+        Assert.Equal(2, errors.Count);
+        Assert.Contains("[0]", errors.Keys);
+        Assert.Contains("[1]", errors.Keys);
     }
 
     [Fact]

--- a/tests/MiniValidation.UnitTests/TestTypes.cs
+++ b/tests/MiniValidation.UnitTests/TestTypes.cs
@@ -82,6 +82,22 @@ class TestClassLevelValidatableOnlyTypeWithServiceProvider : IValidatableObject
     }
 }
 
+class TestTypeWithClassLevelValidation : IValidatableObject
+{
+    [Required]
+    public string? RequiredName { get; set; } = "Default";
+
+    public bool IsValid { get; set; } = true;
+
+    public IEnumerable<ValidationResult> Validate(ValidationContext validationContext)
+    {
+        if (!IsValid)
+        {
+            yield return new ValidationResult($"{validationContext.DisplayName} is invalid.");
+        }
+    }
+}
+
 class TestClassWithEnumerable<TEnumerable>
 {
     public IEnumerable<TEnumerable>? Enumerable { get; set; }

--- a/tests/MiniValidation.UnitTests/TryValidate.cs
+++ b/tests/MiniValidation.UnitTests/TryValidate.cs
@@ -264,7 +264,7 @@ public class TryValidate
     }
 
     [Fact]
-    public void ValidatableObject_Is_Not_Validated_When_Has_Invalid_Attributes()
+    public void ValidatableObject_Validate_Member_Errors_Are_Aggregated_With_Invalid_Attributes()
     {
         var thingToValidate = new TestValidatableType
         {
@@ -275,8 +275,26 @@ public class TryValidate
         var result = MiniValidator.TryValidate(thingToValidate, out var errors);
 
         Assert.False(result);
-        Assert.Single(errors);
-        Assert.Equal(nameof(TestValidatableType.TenOrMore), errors.Keys.First());
+        Assert.Equal(2, errors.Count);
+        Assert.Contains(nameof(TestValidatableType.TenOrMore), errors.Keys);
+        Assert.Contains(nameof(TestValidatableType.TwentyOrMore), errors.Keys);
+    }
+
+    [Fact]
+    public void ValidatableObject_Validate_Class_Level_Errors_Are_Aggregated_With_Invalid_Attributes()
+    {
+        var thingToValidate = new TestTypeWithClassLevelValidation
+        {
+            RequiredName = null,
+            IsValid = false
+        };
+
+        var result = MiniValidator.TryValidate(thingToValidate, out var errors);
+
+        Assert.False(result);
+        Assert.Equal(2, errors.Count);
+        Assert.Contains(nameof(TestTypeWithClassLevelValidation.RequiredName), errors.Keys);
+        Assert.Contains("", errors.Keys);
     }
 
     [Fact]


### PR DESCRIPTION
## Summary
- Report every invalid item in enumerable validation instead of stopping at the first invalid item
- Aggregate IValidatableObject member and class-level results with property validation results
- Preserve item paths for class-level errors from enumerable entries

Fixes #68
Fixes #34

## Testing
- dotnet test .\tests\MiniValidation.UnitTests\MiniValidation.UnitTests.csproj -f net8.0 --no-restore --verbosity minimal
- dotnet build .\src\MiniValidation\MiniValidation.csproj --no-restore --verbosity minimal

Note: an initial full test attempt could not run net471 because the .NET Framework 4.7.1 targeting pack is not installed in this environment.