### PR TITLE
Fix issue #79 duplicate validation errors

### DIFF
--- a/.github/workflows/_build.yml
+++ b/.github/workflows/_build.yml
@@ -19,7 +19,10 @@ jobs:
     - name: Install .NET SDK
       uses: actions/setup-dotnet@v4
       with:
-        dotnet-version: 6.0.x
+        dotnet-version: |
+          8.0.x
+          9.0.x
+          10.0.x
         global-json-file: "./global.json"
     
     - name: Restore dependencies

--- a/global.json
+++ b/global.json
@@ -1,6 +1,6 @@
 {
   "sdk": {
-    "version": "8.0.100",
+    "version": "10.0.100",
     "rollForward": "latestFeature"
   }
 }

--- a/samples/Samples.Console/Samples.Console.csproj
+++ b/samples/Samples.Console/Samples.Console.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
   </PropertyGroup>
 

--- a/samples/Samples.Web/Samples.Web.csproj
+++ b/samples/Samples.Web/Samples.Web.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>net7.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
   </PropertyGroup>

--- a/src/MiniValidation/MiniValidation.csproj
+++ b/src/MiniValidation/MiniValidation.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <Description>A minimalist validation library built atop the existing validation features in .NET's `System.ComponentModel.DataAnnotations` namespace.</Description>
-    <TargetFrameworks>netstandard2.0;net6.0</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;net8.0</TargetFrameworks>
     <PackageTags>ComponentModel DataAnnotations validation</PackageTags>
     <PackageReadmeFile>README.md</PackageReadmeFile>
     <LangVersion>10.0</LangVersion>

--- a/src/MiniValidation/TypeDetailsCache.cs
+++ b/src/MiniValidation/TypeDetailsCache.cs
@@ -14,6 +14,21 @@ internal class TypeDetailsCache
     private static readonly PropertyDetails[] _emptyPropertyDetails = Array.Empty<PropertyDetails>();
     private readonly ConcurrentDictionary<Type, (PropertyDetails[] Properties, bool RequiresAsync)> _cache = new();
 
+    public TypeDetailsCache()
+    {
+        TypeDescriptor.Refreshed += args =>
+        {
+            if (args.TypeChanged is { } type)
+            {
+                _cache.TryRemove(type, out _);
+            }
+            else
+            {
+                _cache.Clear();
+            }
+        };
+    }
+
     public (PropertyDetails[] Properties, bool RequiresAsync) Get(Type? type)
     {
         if (type is null)
@@ -183,16 +198,17 @@ internal class TypeDetailsCache
             }
         }
 
-        var propertyAttributes = property.GetCustomAttributes();
+        var propertyAttributes = property.GetCustomAttributes().ToArray();
         var customAttributes = paramAttributes is not null
             ? paramAttributes.Concat(propertyAttributes)
-            : propertyAttributes;
+            : propertyAttributes.AsEnumerable();
 
         if (TryGetAttributesViaTypeDescriptor(property, out var typeDescriptorAttributes))
         {
             customAttributes = customAttributes
-                .Concat(typeDescriptorAttributes.Cast<Attribute>())
-                .Distinct();
+                .Concat(typeDescriptorAttributes
+                    .Cast<Attribute>()
+                    .Where(attr => !IsDuplicateTypeDescriptorAttribute(attr, propertyAttributes)));
         }
 
         foreach (var attr in customAttributes)
@@ -213,6 +229,116 @@ internal class TypeDetailsCache
         }
 
         return new(validationAttributes?.ToArray(), displayAttribute, skipRecursionAttribute);
+    }
+
+    private static bool IsDuplicateTypeDescriptorAttribute(Attribute typeDescriptorAttribute, Attribute[] propertyAttributes)
+    {
+        foreach (var propertyAttribute in propertyAttributes)
+        {
+            if (AreEquivalentAttributes(propertyAttribute, typeDescriptorAttribute))
+            {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    private static bool AreEquivalentAttributes(Attribute left, Attribute right)
+    {
+        if (ReferenceEquals(left, right))
+        {
+            return true;
+        }
+
+        if (left is not ValidationAttribute || right is not ValidationAttribute)
+        {
+            return false;
+        }
+
+        var attributeType = left.GetType();
+        if (attributeType != right.GetType() || !Equals(left.TypeId, right.TypeId))
+        {
+            return false;
+        }
+
+        foreach (var property in attributeType.GetProperties(BindingFlags.Instance | BindingFlags.Public))
+        {
+            if (!property.CanRead || property.GetIndexParameters().Length > 0)
+            {
+                continue;
+            }
+
+            if (!TryGetPropertyValue(property, left, out var leftValue)
+                || !TryGetPropertyValue(property, right, out var rightValue)
+                || !AreAttributeValuesEqual(leftValue, rightValue))
+            {
+                return false;
+            }
+        }
+
+        if (attributeType.Assembly != typeof(ValidationAttribute).Assembly)
+        {
+            for (var currentType = attributeType; currentType is not null && currentType != typeof(object); currentType = currentType.BaseType)
+            {
+                foreach (var field in currentType.GetFields(BindingFlags.DeclaredOnly | BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic))
+                {
+                    if (!AreAttributeValuesEqual(field.GetValue(left), field.GetValue(right)))
+                    {
+                        return false;
+                    }
+                }
+            }
+        }
+
+        return true;
+    }
+
+    private static bool TryGetPropertyValue(PropertyInfo property, Attribute attribute, out object? value)
+    {
+        try
+        {
+            value = property.GetValue(attribute);
+            return true;
+        }
+        catch
+        {
+            value = null;
+            return false;
+        }
+    }
+
+    private static bool AreAttributeValuesEqual(object? left, object? right)
+    {
+        if (ReferenceEquals(left, right))
+        {
+            return true;
+        }
+
+        if (left is null || right is null)
+        {
+            return false;
+        }
+
+        if (left is Array leftArray && right is Array rightArray)
+        {
+            if (leftArray.Length != rightArray.Length)
+            {
+                return false;
+            }
+
+            for (var i = 0; i < leftArray.Length; i++)
+            {
+                if (!Equals(leftArray.GetValue(i), rightArray.GetValue(i)))
+                {
+                    return false;
+                }
+            }
+
+            return true;
+        }
+
+        return Equals(left, right);
     }
 
     private static bool TryGetAttributesViaTypeDescriptor(PropertyInfo property, [NotNullWhen(true)] out IEnumerable<Attribute>? typeDescriptorAttributes)

--- a/src/MiniValidation/TypeDetailsCache.cs
+++ b/src/MiniValidation/TypeDetailsCache.cs
@@ -36,12 +36,13 @@ internal class TypeDetailsCache
             return (_emptyPropertyDetails, false);
         }
 
-        if (!_cache.ContainsKey(type))
+        (PropertyDetails[] Properties, bool RequiresAsync) details;
+        while (!_cache.TryGetValue(type, out details))
         {
             Visit(type);
         }
 
-        return _cache[type];
+        return details;
     }
 
     private void Visit(Type type)

--- a/tests/MiniValidation.Benchmarks/MiniValidation.Benchmarks.csproj
+++ b/tests/MiniValidation.Benchmarks/MiniValidation.Benchmarks.csproj
@@ -2,8 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFrameworks>net6.0;net7.0</TargetFrameworks>
-    <TargetFrameworks Condition=" $([MSBuild]::IsOsPlatform('Windows')) ">net471;net6.0;net7.0</TargetFrameworks>
+    <TargetFrameworks>net8.0;net9.0;net10.0</TargetFrameworks>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <LangVersion>10</LangVersion>

--- a/tests/MiniValidation.UnitTests/MiniValidation.UnitTests.csproj
+++ b/tests/MiniValidation.UnitTests/MiniValidation.UnitTests.csproj
@@ -1,8 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net6.0;net7.0;net8.0</TargetFrameworks>
-    <TargetFrameworks Condition=" $([MSBuild]::IsOsPlatform('Windows')) ">net471;net6.0;net7.0;net8.0</TargetFrameworks>
+    <TargetFrameworks>net8.0;net9.0;net10.0</TargetFrameworks>
     <LangVersion>10.0</LangVersion>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>

--- a/tests/MiniValidation.UnitTests/TryValidate.cs
+++ b/tests/MiniValidation.UnitTests/TryValidate.cs
@@ -464,4 +464,80 @@ public class TryValidate
         Assert.Single(errors["PropertyToBeRequired"]);
         Assert.Single(errors["AnotherProperty"]);
     }
+
+    [Fact]
+    public void TryValidate_Does_Not_Duplicate_Validation_Attributes_From_TypeDescriptor()
+    {
+        var thingToValidate = new TestTypeWithMinLength { ErrorCode = "12" };
+
+        var result = MiniValidator.TryValidate(thingToValidate, out var errors);
+
+        Assert.False(result);
+        var entry = Assert.Single(errors);
+        Assert.Equal(nameof(TestTypeWithMinLength.ErrorCode), entry.Key);
+        Assert.Single(entry.Value);
+    }
+
+    [Fact]
+    public void TryValidate_Preserves_Multiple_Distinct_Validation_Attributes_Of_Same_Type()
+    {
+        var thingToValidate = new TestTypeWithMultipleSameTypeValidationAttributes();
+
+        var result = MiniValidator.TryValidate(thingToValidate, out var errors);
+
+        Assert.False(result);
+        var entry = Assert.Single(errors);
+        Assert.Equal(nameof(TestTypeWithMultipleSameTypeValidationAttributes.Name), entry.Key);
+        Assert.Equal(new[] { "Invalid.", "Invalid." }, entry.Value);
+    }
+
+    [Fact]
+    public void TryValidate_Preserves_Distinct_Validation_Attribute_Attached_Via_TypeDescriptor()
+    {
+        typeof(TestTypeWithMinLengthAndTypeDescriptorAttribute).AttachAttribute(
+            nameof(TestTypeWithMinLengthAndTypeDescriptorAttribute.ErrorCode),
+            _ => new MinLengthAttribute(5));
+
+        var thingToValidate = new TestTypeWithMinLengthAndTypeDescriptorAttribute { ErrorCode = "12" };
+
+        var result = MiniValidator.TryValidate(thingToValidate, out var errors);
+
+        Assert.False(result);
+        var entry = Assert.Single(errors);
+        Assert.Equal(nameof(TestTypeWithMinLengthAndTypeDescriptorAttribute.ErrorCode), entry.Key);
+        Assert.Equal(2, entry.Value.Length);
+    }
+
+    class TestTypeWithMinLength
+    {
+        [MinLength(3)]
+        public string? ErrorCode { get; set; }
+    }
+
+    class TestTypeWithMinLengthAndTypeDescriptorAttribute
+    {
+        [MinLength(3)]
+        public string? ErrorCode { get; set; }
+    }
+
+    class TestTypeWithMultipleSameTypeValidationAttributes
+    {
+        [AlwaysInvalid("First")]
+        [AlwaysInvalid("Second")]
+        public string? Name { get; set; }
+    }
+
+    [AttributeUsage(AttributeTargets.Property, AllowMultiple = true)]
+    class AlwaysInvalidAttribute : ValidationAttribute
+    {
+        public AlwaysInvalidAttribute(string id)
+        {
+            Id = id;
+            ErrorMessage = "Invalid.";
+        }
+
+        public string Id { get; }
+
+        public override bool IsValid(object? value) => false;
+    }
 }


### PR DESCRIPTION
Fixes #79

## Summary
- Ignore validation attributes surfaced through TypeDescriptor when they are equivalent to attributes already read from reflection.
- Preserve distinct validation attributes, including TypeDescriptor-attached attributes.
- Refresh cached type details when TypeDescriptor providers change.

## Testing
- `dotnet test tests\MiniValidation.UnitTests\MiniValidation.UnitTests.csproj -f net8.0 --no-restore --verbosity minimal`
- `dotnet build src\MiniValidation\MiniValidation.csproj --no-restore --verbosity minimal`