### PR TITLE
Improve AdaptiveCapacityDictionary debugger display

### DIFF
--- a/src/MiniValidation/AdaptiveCapacityDictionary.cs
+++ b/src/MiniValidation/AdaptiveCapacityDictionary.cs
@@ -15,6 +15,8 @@ namespace MiniValidation;
 /// <summary>
 /// An <see cref="IDictionary{TKey, TValue}"/> type to hold a small amount of items (10 or less in the common case).
 /// </summary>
+[DebuggerDisplay("Count = {Count}")]
+[DebuggerTypeProxy(typeof(Diagnostics.CollectionDebugView))]
 internal sealed class AdaptiveCapacityDictionary<TKey, TValue> : IDictionary<TKey, TValue>, IReadOnlyDictionary<TKey, TValue> where TKey : notnull
 {
     // Threshold for size of array to use.

--- a/src/MiniValidation/Diagnostics/CollectionDebugView.cs
+++ b/src/MiniValidation/Diagnostics/CollectionDebugView.cs
@@ -1,0 +1,31 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+#if NET6_0_OR_GREATER
+using System.Collections;
+using System.Diagnostics;
+using System.Diagnostics.CodeAnalysis;
+using System.Linq;
+
+namespace MiniValidation.Diagnostics;
+
+/// <summary>
+/// Allows the debugger to display collections.
+/// </summary>
+[ExcludeFromCodeCoverage]
+internal sealed class CollectionDebugView
+{
+    private readonly IEnumerable _enumeration;
+
+    public CollectionDebugView(IEnumerable enumeration)
+    {
+        _enumeration = enumeration;
+    }
+
+    /// <summary>
+    /// Gets the array that is shown by the debugger.
+    /// </summary>
+    [DebuggerBrowsable(DebuggerBrowsableState.RootHidden)]
+    public object[] Items => _enumeration.Cast<object>().ToArray();
+}
+#endif


### PR DESCRIPTION
Replaces #77 with the same debugger experience improvement rebased onto current `main` and cleaned up formatting.

## Summary
- Adds `DebuggerDisplay` and `DebuggerTypeProxy` to `AdaptiveCapacityDictionary<TKey, TValue>`
- Adds an internal `CollectionDebugView` used by the debugger proxy

## Validation
- `dotnet test tests\MiniValidation.UnitTests\MiniValidation.UnitTests.csproj -f net8.0 --nologo --verbosity minimal`
