### PR TITLE
Pin GitHub Actions to latest SHAs

### DIFF
--- a/.github/workflows/_build.yml
+++ b/.github/workflows/_build.yml
@@ -14,10 +14,10 @@ jobs:
     name: Build & Test
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
     
     - name: Install .NET SDK
-      uses: actions/setup-dotnet@v4
+      uses: actions/setup-dotnet@c2fa09f4bde5ebb9d1777cf28262a3eb3db3ced7 # v5.2.0
       with:
         dotnet-version: |
           8.0.x
@@ -58,7 +58,7 @@ jobs:
       run: dotnet pack --configuration Release --output ./artifacts/ship --verbosity normal -p:BuildNumber=$BUILD_NUMBER -p:SourceRevisionId=$GITHUB_SHA -p:ContinuousIntegrationBuild=true -p:IsShipCandidate=true
 
     - name: Upload artifacts (packages)
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
       with:
         name: nupkg
         path: ./artifacts/**/*.nupkg

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,10 +27,10 @@ jobs:
 
     steps:
       - name: Download artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
 
       - name: Setup .NET SDK
-        uses: actions/setup-dotnet@v4
+        uses: actions/setup-dotnet@c2fa09f4bde5ebb9d1777cf28262a3eb3db3ced7 # v5.2.0
 
       - name: Add GitHub Package Repository source
         run: dotnet nuget add source --username ${{ secrets.GPR_USERNAME }} --password ${{ secrets.GITHUB_TOKEN }} --store-password-in-clear-text --name GPR ${{ secrets.GPR_URI }}
@@ -39,7 +39,7 @@ jobs:
         run: dotnet nuget push **/ci/*.nupkg -s "GPR" --skip-duplicate
 
       - name: Delete old packages
-        uses: smartsquaregmbh/delete-old-packages@v0.5.0
+        uses: smartsquaregmbh/delete-old-packages@78421c4341be2a20cc4766902b4dc2925efa5117 # v1.0.0
         with:
           keep: 5
           names: ${{ env.PACKAGE_ID }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -28,13 +28,13 @@ jobs:
           curl -s -H "Accept: application/json" "${workflowUrl}" > workflow_details.json
 
       - name: Extract workflow run commit SHA
-        uses: sergeysova/jq-action@v2
+        uses: sergeysova/jq-action@a3f0d4ff59cc1dddf023fc0b325dd75b10deec58 # v2.3.0
         id: workflowsha
         with:
           cmd: 'jq .head_sha workflow_details.json -r'
 
       - name: Download workflow run artifacts
-        uses: dawidd6/action-download-artifact@v3
+        uses: dawidd6/action-download-artifact@b6e2e70617bc3265edd6dab6c906732b2f1ae151 # v21
         with:
           run_id: ${{ inputs.runId }}
           workflow_conclusion: success
@@ -66,7 +66,7 @@ jobs:
           fi
 
       - name: Create release
-        uses: ncipollo/release-action@v1
+        uses: ncipollo/release-action@339a81892b84b4eeb0f6e744e4574d79d0d9b8dd # v1.21.0
         with:
           tag: v${{ env.PACKAGE_VERSION }}
           commit: ${{ steps.workflowsha.outputs.value }}
@@ -75,11 +75,11 @@ jobs:
           prerelease: ${{ contains(env.PACKAGE_VERSION, '-') }}
 
       - name: Setup .NET SDK
-        uses: actions/setup-dotnet@v4
+        uses: actions/setup-dotnet@c2fa09f4bde5ebb9d1777cf28262a3eb3db3ced7 # v5.2.0
 
       - name: NuGet login (OIDC)
         id: nuget-login
-        uses: NuGet/login@v1
+        uses: NuGet/login@8d196754b4036150537f80ac539e15c2f1028841 # v1.2.0
         with:
           user: ${{ github.repository_owner }}
 


### PR DESCRIPTION
## Summary
- update GitHub Actions workflow references to the current latest action versions
- pin external actions to immutable commit SHAs
- include inline comments with the corresponding version tags

## Validation
- `dotnet test tests\MiniValidation.UnitTests\MiniValidation.UnitTests.csproj -f net8.0 --nologo --verbosity minimal`
- `actionlint`