### PR TITLE
Set package type for cleanup action

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,3 +43,4 @@ jobs:
         with:
           keep: 5
           names: ${{ env.PACKAGE_ID }}
+          type: nuget


### PR DESCRIPTION
## Summary
- fix the failed `CI (main)` deploy job after updating `smartsquaregmbh/delete-old-packages` to v1.0.0
- set the required package `type` input to `nuget`

## Validation
- `actionlint`