### PR TITLE
Set package owner for cleanup action

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,3 +44,4 @@ jobs:
           keep: 5
           names: ${{ env.PACKAGE_ID }}
           type: nuget
+          user: ${{ github.repository_owner }}


### PR DESCRIPTION
## Summary
- fix the latest `CI (main)` deploy failure from `smartsquaregmbh/delete-old-packages@v1.0.0`
- set the required package owner input with `user: ${{ github.repository_owner }}`

## Validation
- `actionlint`